### PR TITLE
add page shouldnt contain status initially other than in progress

### DIFF
--- a/frontend/lib/pages/projects/add_project.dart
+++ b/frontend/lib/pages/projects/add_project.dart
@@ -86,7 +86,7 @@ class _AddProjectPageState extends State<AddProjectPage> {
               ),
               const SizedBox(height: 16),
               AppSearchableDropdown<String>(
-                items: ['in_progress', 'completed'],
+                items: ['in_progress'],
                 label: 'Status',
                 initialValue: 'in_progress',
                 itemAsString: (status) => status,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove the "completed" option from the status dropdown on the add project page